### PR TITLE
Add defaultTranslations with priority

### DIFF
--- a/src/main/java/com/aesefficio/interiors/CreateInteriors.java
+++ b/src/main/java/com/aesefficio/interiors/CreateInteriors.java
@@ -20,10 +20,12 @@ import net.minecraft.resources.ResourceLocation;
 #if forge
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.fml.common.Mod;
 #elif neoforge
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.fml.common.Mod;
 #elif fabric
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
@@ -80,7 +82,7 @@ public final class CreateInteriors
 		REGISTRATE.registerEventListeners(modBus);
 		init();
 		CITab.register(modBus);
-		modBus.addListener(this::gatherData);
+		modBus.addListener(EventPriority.HIGH, this::gatherData);
 	}
 
 	public void gatherData(GatherDataEvent event) {


### PR DESCRIPTION
this fixes a race condition issue happening with datagen that I observed in a project of mine that includes this mod at runtime when testing in dev.
This also happens when cloning your repository and running the `Neoforge Data: 1.21.1` task.

By adding a priority to the event listener this race condition is resolved and it always happens before the registrate provider is set